### PR TITLE
feat: update Dockerfile to uv instead of pip

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,30 @@
-FROM python:3.12-slim
+FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim
 
 WORKDIR /app
 
-# Install dependencies
-COPY requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
+# Install system dependencies
+RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/*
+
+# Copy dependency files
+COPY pyproject.toml uv.lock ./
+
+# Install dependencies with increased timeout (build-time only)
+ARG UV_HTTP_TIMEOUT=120
+RUN uv sync --frozen
 
 # Copy application code
-COPY app app/
+COPY app/ ./app/
 
 # Set environment variables
-ENV VERIS_API_URL=http://host.docker.internal:8742
+ENV VERIS_API_URL=http://backend:8742
 ENV VERIS_API_VERSION=v3
 
 # Expose port
-EXPOSE 8081
+EXPOSE 8000
+
+# Health check
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
+  CMD curl -f http://localhost:8000/health || exit 1
 
 # Run the application
-CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8081"]
+CMD ["uv", "run", "uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
## Summary
Updates Dockerfile from pip-based to uv-based dependency management to match the project's actual dependency setup (`pyproject.toml` + `uv.lock`).

## Changes
- ✅ Switch from `python:3.12-slim` to `ghcr.io/astral-sh/uv:python3.12-bookworm-slim`
- ✅ Use `uv sync` instead of `pip install requirements.txt`
- ✅ Copy `pyproject.toml` and `uv.lock` instead of `requirements.txt`
- ✅ Add `ARG UV_HTTP_TIMEOUT=120` for build-time network timeout handling
- ✅ Use `--frozen` flag for deterministic builds
- ✅ Add health check with curl
- ✅ Install curl for health check support
- ✅ Change port from 8081 to 8000 to match current usage
- ✅ Update `VERIS_API_URL` to `http://backend:8742` for docker-compose compatibility
- ✅ Update CMD to use `"uv run"` for proper uv environment activation

## Why
The old Dockerfile expected `requirements.txt` but the project uses `pyproject.toml` + `uv.lock`, causing builds to fail with:
```
COPY requirements.txt .
ERROR: "/requirements.txt": not found
```

## Benefits
- ✅ Dockerfile now matches project's actual dependency management
- ✅ Consistent with backend service Dockerfile pattern
- ✅ Enables proper Docker-based local development with docker-compose
- ✅ Faster, more reliable builds with uv
- ✅ Deterministic builds with `--frozen` flag
- ✅ Container health checks for orchestration

## Testing
Tested with `docker-compose` alongside full stack (backend, frontend, redis, temporal):
```bash
docker-compose -f docker-compose.local.yaml up -d
curl http://localhost:8000/health  # {"status":"ok"}
```

All services healthy and communicating properly via Docker network.

🤖 Generated with [Claude Code](https://claude.com/claude-code)